### PR TITLE
Replace request / request promise with axios

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 This package is a wrapper around the [Oanda Rest-v20 api][oanda-api]. All request parameters, payloads or response structures are documented there so you won't find that information here.
 
-The purpose of this package is to simplify the url constructions and expose the endpoints in a nice way for any Nodejs based projects. The package should also work as described in browsers via `fx` global or by `require` / `import`. 
+The purpose of this package is to simplify the url constructions and expose the endpoints in a nice way for any Nodejs based projects. The package should also work as described in browsers via `fx` global or by `require` / `import`.
 
 Here is an example:
 
@@ -63,7 +63,7 @@ fx.configure({
   version: 'v3',      // Probably never need to change this
   accountId: '23243', // Set this if you know the accountId up front
   dateTimeFormat: 'RFC3339', // Per oanda documentation
-  throwHttpErrors : true // * See notes
+  fullResponse : true // * See notes
 });
 
 // You needn't set all values, a more realistic example may be like
@@ -72,11 +72,22 @@ fx.configure({ live: true, accountId: '111-002-111-2' });
 
 - `apiKey` - Default: env variable `OANDA_API_KEY`. Sets the `Authorization` header key.  Best practice would be to use some config or env management package to set this and never pass the value. But you can if you want.
 
-- `live` - Default: false. This affects the endpoint url. If set to true the host is `fxtrade.oanda.com`, when false its `fxpractice.oanda.com`
+- `live` - Default: `false`. This affects the endpoint url. If set to true the host is `fxtrade.oanda.com`, when false its `fxpractice.oanda.com`
 
-- `accountId` - Default: not set. If you know the accountId you could set it here. Most endpoints need the accountId set
+- `accountId` - Default: `not set`. If you know the accountId you could set it here. Most endpoints need the accountId set
 
-- `throwHttpErrors` translates directly to the [`request-promise`][request-promise] package options `simple` and `resolveWithFullResponse`. How this relates is that when true, error http codes will return as a rejection and successful responses only resolve the `body` of the response. If false, all responses resolve and the response has all of the `httpResponse` properties, such as `statusCode`
+- `fullResponse` - Default: `false`. When this not set to true, you get a short form response for all requests like the following:
+
+    ```json5
+{
+    status: 200,
+    headers: {}, // Some headers
+    candles: []  // The relevant payload that you would expect
+}
+    ```
+
+    if the `fullResponse` is set to true then you get a full [`axios`](https://github.com/mzabriskie/axios) response.
+
 
 If you are messing around on a demo account, with the `OANDA_API_KEY` set, then you may never need to use `configure`. Instead you can just use `setAccount`, in fact for most of the endpoints you must set the account before hand. Heres what it might look like if you maybe know the id.
 
@@ -212,7 +223,7 @@ Good news, both the `pricing` and the `transactions` streams are implemented. He
 
 ```javascript
 // GET /accounts/:accountId/pricing/stream?instruments=AUD_USD
-const stream = fx.pricing.stream({ instruments: 'AUD_USD' });
+const stream = await fx.pricing.stream({ instruments: 'AUD_USD' });
 
 // Handle some data
 stream.on('data', data => {

--- a/index.coffee
+++ b/index.coffee
@@ -1,7 +1,7 @@
 axios = require 'axios'
 resources = require './lib'
 Subscription = require './lib/subscription'
-{omit} = require './lib/utils'
+{omit, assign} = require './lib/utils'
 
 # Return a replacement with the new httpMethod
 fx = (method) ->
@@ -10,7 +10,7 @@ fx = (method) ->
 
 # Allows configuration of the fx api
 fx.configure = (options) ->
-  @options = Object.assign {}, @options, options
+  @options = assign {}, @options, options
 
 # Set the account id context as its needed for most routes
 fx.setAccount = (id) -> @options.accountId = id
@@ -41,8 +41,6 @@ fx.request = (req, route, checkAccount = true) ->
       'Accept-Datetime-Format': @options.dateTimeFormat
     data: req.body
     params: omit req, 'body'
-    # resolveWithFullResponse: not @options.throwHttpErrors
-    # simple: @options.throwHttpErrors
     responseType
   }
 
@@ -53,10 +51,10 @@ fx.request = (req, route, checkAccount = true) ->
   # TODO: The ? are hacks because of the annoying testdouble framework
   # Need to remove them from here and also from the subscribe below
   return deferred
-    ?.then ({status, headers, data}) -> Object.assign {}, {status, headers}, data
+    ?.then ({status, headers, data}) -> assign {}, {status, headers}, data
     ?.catch ({response}) ->
       {status, headers, data} = response
-      Promise.reject Object.assign {}, {status, headers}, data
+      Promise.reject assign {}, {status, headers}, message: data
 
 
 fx.subscribe = (req, route, checkAccount = true) ->
@@ -117,7 +115,7 @@ bootstrap = ->
   }
 
   # Attach additional functions to the api
-  Object.assign fx, resources
+  assign fx, resources
 
   return _bindAll resources, fx
 

--- a/index.coffee
+++ b/index.coffee
@@ -54,7 +54,7 @@ fx.request = (req, route, checkAccount = true) ->
     ?.then ({status, headers, data}) -> assign {}, {status, headers}, data
     ?.catch ({response}) ->
       {status, headers, data} = response
-      Promise.reject assign {}, {status, headers}, message: data
+      Promise.reject assign {}, {status, headers}, data
 
 
 fx.subscribe = (req, route, checkAccount = true) ->

--- a/index.coffee
+++ b/index.coffee
@@ -1,5 +1,4 @@
-rp = require 'request-promise-native'
-request = require 'request'
+axios = require 'axios'
 resources = require './lib'
 Subscription = require './lib/subscription'
 {omit} = require './lib/utils'
@@ -30,37 +29,53 @@ fx.request = (req, route, checkAccount = true) ->
   method = @method ? 'GET'
   @method = null
 
-  return rp {
+  responseType = 'json'
+
+  if req.json? and !req.json then responseType = 'text'
+
+  options = {
     method
-    uri: req.uri ? @endpoint route
+    url: req.url ? @endpoint route
     headers:
       Authorization: "Bearer #{@options.apiKey}"
       'Accept-Datetime-Format': @options.dateTimeFormat
-    body: req.body
-    qs: omit req, 'body'
-    resolveWithFullResponse: not @options.throwHttpErrors
-    simple: @options.throwHttpErrors
-    json: req.json ? true
+    data: req.body
+    params: omit req, 'body'
+    # resolveWithFullResponse: not @options.throwHttpErrors
+    # simple: @options.throwHttpErrors
+    responseType
   }
+
+  deferred = axios options
+
+  if @options.fullResponse then return deferred
+
+  # TODO: The ? are hacks because of the annoying testdouble framework
+  # Need to remove them from here and also from the subscribe below
+  return deferred
+    ?.then ({status, headers, data}) -> Object.assign {}, {status, headers}, data
+    ?.catch ({response}) ->
+      {status, headers, data} = response
+      Promise.reject Object.assign {}, {status, headers}, data
+
 
 fx.subscribe = (req, route, checkAccount = true) ->
   _validateRequest @options, checkAccount
 
   options = {
-    method: @method
-    uri: req.uri ? @endpoint route, 'stream'
+    method: 'GET'
+    url: req.url ? @endpoint route, 'stream'
     headers:
       Authorization: "Bearer #{@options.apiKey}"
       'Accept-Datetime-Format': @options.dateTimeFormat
-    qs: omit req, 'body'
-    json: req.json ? true
+    params: omit req, 'body'
+    responseType: 'stream'
   }
 
   @method = null
 
-  return new Subscription request(options, (err, res) ->
-    if err then throw new Error "Failed to subscribe to: #{options.uri}"
-  ), json: options.json
+  axios(options)?.then ({data}) -> new Subscription data, json: req.json ? true
+
 
 # Get the fx api endpoint adjusted per route
 fx.endpoint = (route = '', mode = 'api') ->

--- a/lib/subscription.coffee
+++ b/lib/subscription.coffee
@@ -7,7 +7,7 @@ class Subscription extends EventEmitter
 
     @connected = false
     @stream = stream
-    @options = Object.assign {}, json: true, options
+    @options = Object.assign {}, options
 
     @stream.on 'data', (data) =>
       @connected = true
@@ -29,6 +29,6 @@ class Subscription extends EventEmitter
 
   disconnect: ->
     @connected = false
-    @stream.abort()
+    @stream.req.abort()
 
 module.exports = Subscription

--- a/lib/subscription.coffee
+++ b/lib/subscription.coffee
@@ -1,4 +1,5 @@
 {EventEmitter} = require 'events'
+{assign} = require './utils'
 
 class Subscription extends EventEmitter
   constructor: (stream, options) ->
@@ -7,7 +8,7 @@ class Subscription extends EventEmitter
 
     @connected = false
     @stream = stream
-    @options = Object.assign {}, options
+    @options = assign {}, options
 
     @stream.on 'data', (data) =>
       @connected = true

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -5,8 +5,9 @@ exports.validate = (req, required) ->
 
   if invalid.length > 0 then throw new Error "Required parameters missing: #{invalid.join ', '}"
 
+exports.assign = require 'lodash/assign'
 
 exports.omit = (object, key) ->
-  result = Object.assign {}, object
+  result = exports.assign {}, object
   delete result[key]
   return result

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,9 +24,10 @@
       }
     },
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
+      "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
+      "dev": true
     },
     "ajv-keywords": {
       "version": "2.1.0",
@@ -91,7 +92,8 @@
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
     },
     "asn1.js": {
       "version": "4.9.1",
@@ -108,7 +110,8 @@
     "assert-plus": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "dev": true
     },
     "assertion-error": {
       "version": "1.0.2",
@@ -131,17 +134,25 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "aws-sign2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "dev": true
     },
     "aws4": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "dev": true
+    },
+    "axios": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
+      "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0="
     },
     "babel-cli": {
       "version": "6.24.1",
@@ -495,6 +506,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
       "optional": true
     },
     "big.js": {
@@ -518,7 +530,8 @@
     "boom": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -623,9 +636,10 @@
       "dev": true
     },
     "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "dev": true
     },
     "center-align": {
       "version": "0.1.3",
@@ -674,7 +688,8 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -723,7 +738,8 @@
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "dev": true
     },
     "commander": {
       "version": "2.11.0",
@@ -779,40 +795,10 @@
       "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
       "dev": true,
       "dependencies": {
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "dev": true
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true
-        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-          "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.79.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "dev": true
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
           "dev": true
         }
       }
@@ -838,7 +824,8 @@
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true
     },
     "crypto-browserify": {
       "version": "3.11.1",
@@ -856,11 +843,13 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
         }
       }
     },
@@ -873,8 +862,7 @@
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
     },
     "decamelize": {
       "version": "1.2.0",
@@ -899,7 +887,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "des.js": {
       "version": "1.0.0",
@@ -941,6 +930,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
       "optional": true
     },
     "electron-to-chromium": {
@@ -1084,7 +1074,8 @@
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
     },
     "extglob": {
       "version": "0.3.2",
@@ -1095,7 +1086,8 @@
     "extsprintf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "1.0.0",
@@ -1127,6 +1119,11 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.4.tgz",
+      "integrity": "sha512-Suw6KewLV2hReSyEOeql+UUkBVyiBm3ok1VPrVFRZnQInWpdoZbbiG5i8aJVSjTr0yQ4Ava0Sh6/joCg1Brdqw=="
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -1142,12 +1139,14 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE="
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "dev": true
     },
     "fs-readdir-recursive": {
       "version": "1.0.0",
@@ -1840,11 +1839,13 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
         }
       }
     },
@@ -1890,15 +1891,11 @@
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
-    "har-schema": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
-    },
     "har-validator": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "dev": true
     },
     "has-ansi": {
       "version": "2.0.0",
@@ -1927,7 +1924,8 @@
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -1938,7 +1936,8 @@
     "hoek": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -1955,7 +1954,8 @@
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "dev": true
     },
     "https-browserify": {
       "version": "0.0.1",
@@ -2026,8 +2026,7 @@
     "is-buffer": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-      "dev": true
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -2122,7 +2121,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -2145,7 +2145,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -2163,6 +2164,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
       "optional": true
     },
     "jsesc": {
@@ -2180,7 +2182,8 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
@@ -2191,12 +2194,14 @@
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json3": {
       "version": "3.3.2",
@@ -2213,7 +2218,8 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
     },
     "jsonpointer": {
       "version": "4.0.1",
@@ -2225,11 +2231,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
+      "dev": true,
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
         }
       }
     },
@@ -2284,7 +2292,8 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -2385,12 +2394,14 @@
     "mime-db": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE="
+      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "dev": true
     },
     "minimalistic-assert": {
       "version": "1.0.0",
@@ -2463,8 +2474,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
       "version": "2.6.2",
@@ -3450,7 +3460,8 @@
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -3578,11 +3589,6 @@
       "integrity": "sha1-vjZ4XFBn6kjYBv+SMojF91C2uKI=",
       "dev": true
     },
-    "performance-now": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
-    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -3652,12 +3658,14 @@
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
     },
     "qs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+      "dev": true
     },
     "querystring": {
       "version": "0.2.0",
@@ -3824,19 +3832,10 @@
       "dev": true
     },
     "request": {
-      "version": "2.81.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA="
-    },
-    "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY="
-    },
-    "request-promise-native": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.4.tgz",
-      "integrity": "sha1-hpiOyO7kCORVefzoO/0Fs635oVU="
+      "version": "2.79.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -3871,7 +3870,8 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
     },
     "semver": {
       "version": "5.3.0",
@@ -3912,7 +3912,8 @@
     "sntp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true
     },
     "source-list-map": {
       "version": "2.0.0",
@@ -3960,18 +3961,15 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "dev": true,
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
         }
       }
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-browserify": {
       "version": "2.0.1",
@@ -4006,7 +4004,8 @@
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -4073,7 +4072,8 @@
     "tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "dev": true
     },
     "trim-right": {
       "version": "1.0.1",
@@ -4088,14 +4088,16 @@
       "dev": true
     },
     "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "dev": true
     },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
       "optional": true
     },
     "type-detect": {
@@ -4174,7 +4176,8 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "dev": true
     },
     "v8flags": {
       "version": "2.1.1",
@@ -4191,7 +4194,8 @@
     "verror": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+      "dev": true
     },
     "vm-browserify": {
       "version": "0.0.4",
@@ -4211,12 +4215,6 @@
       "integrity": "sha1-zi+eB2Vmq6kfdIhxM6iD/X2hh7w=",
       "dev": true,
       "dependencies": {
-        "ajv": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
-          "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
-          "dev": true
-        },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "webpack": "^3.3.0"
   },
   "dependencies": {
-    "request": "^2.81.0",
-    "request-promise-native": "^1.0.3"
+    "axios": "^0.16.2"
   },
   "keywords": [
     "forex",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-fxtrade",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "description": "A node js wrapper for the Oanda Rest v20 api to make things really simple",
   "main": "dist/node.js",
   "browser": "dist/browser.js",

--- a/test/integration/index.coffee
+++ b/test/integration/index.coffee
@@ -73,13 +73,15 @@ describe '--- Integration Tests ---', ->
         fx.setAccount id
         expect(-> fx.pricing.stream()).to.throw 'Required parameters missing: instruments'
 
-      it 'should subscribe to the pricing stream', (done) ->
+      it 'should subscribe to the pricing stream', ->
         fx.setAccount id
-        stream = fx.pricing.stream instruments: 'AUD_USD'
-        stream.on 'data', ({type}) ->
+        stream = await fx.pricing.stream instruments: 'AUD_USD'
+
+        new Promise (resolve) -> stream.on 'data', ({type}) ->
           expect(type).to.match /PRICE|HEARTBEAT/
           stream.disconnect()
-          done()
+          resolve()
+
 
   describe 'transactions', ->
     describe 'GET /accounts/:accountId/transactions[/:id]', ->
@@ -96,13 +98,13 @@ describe '--- Integration Tests ---', ->
         expect(alias).to.be.equal 'Default'
 
     describe 'GET /accounts/:accountId/transactions/stream', ->
-      it 'should subscribe to the transactions stream', (done) ->
+      it 'should subscribe to the transactions stream', ->
         fx.setAccount id
-        stream = fx.transactions.stream()
-        stream.on 'data', ({type}) ->
+        stream = await fx.transactions.stream()
+        new Promise (resolve) -> stream.on 'data', ({type}) ->
           expect(type).to.be.equal 'HEARTBEAT'
           stream.disconnect()
-          done()
+          resolve()
 
   # TODO: Need to fix up these integration tests. Problem is they depend
   # on timing and other irritating factors

--- a/test/integration/index.coffee
+++ b/test/integration/index.coffee
@@ -102,7 +102,7 @@ describe '--- Integration Tests ---', ->
         fx.setAccount id
         stream = await fx.transactions.stream()
         new Promise (resolve) -> stream.on 'data', ({type}) ->
-          expect(type).to.be.equal 'HEARTBEAT'
+          expect(type).to.match /HEARTBEAT|CLIENT_CONFIGURE/
           stream.disconnect()
           resolve()
 

--- a/test/unit/lib/account.coffee
+++ b/test/unit/lib/account.coffee
@@ -3,46 +3,46 @@ td = require 'testdouble'
 contains = td.matchers.contains
 
 fx = {}
-rp = {}
+axios = {}
 
 id = '101-011-5748031-001'
 
 describe 'accounts', ->
   before ->
-    rp = td.replace 'request-promise-native'
+    axios = td.replace 'axios'
     fx = require '../../../index'
 
   describe 'GET /accounts[/:id]', ->
     it 'should pass the parameters got get the accounts', ->
       fx.accounts()
 
-      td.verify rp contains
-        uri: 'https://api-fxpractice.oanda.com/v3/accounts'
+      td.verify axios contains
+        url: 'https://api-fxpractice.oanda.com/v3/accounts'
         method: 'GET'
 
     it 'should pass the parameters to get an account by id', ->
       fx.accounts {id}
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}"
         method: 'GET'
 
   describe 'PATCH /accounts/:id', ->
     it 'should pass the parameters for patching by id', ->
       fx('patch').accounts {id, alias: 'Default'}
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/configuration"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/configuration"
         method: 'PATCH'
-        body: alias: 'Default'
+        data: alias: 'Default'
 
   describe 'GET /accounts/:id/summary', ->
     it 'should pass the parameters to get the account summary', ->
       fx.setAccount id
       fx.summary()
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/summary"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/summary"
         method: 'GET'
 
   describe 'GET /accounts/:id/instruments', ->
@@ -50,8 +50,8 @@ describe 'accounts', ->
       fx.setAccount id
       fx.instruments()
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/instruments"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/instruments"
         method: 'GET'
 
   describe 'GET /accounts/:id/changes', ->
@@ -65,7 +65,7 @@ describe 'accounts', ->
       fx.setAccount id
       fx.changes sinceTransactionID: 20
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/changes"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/changes"
         method: 'GET'
-        qs: sinceTransactionID: 20
+        params: sinceTransactionID: 20

--- a/test/unit/lib/instrument.coffee
+++ b/test/unit/lib/instrument.coffee
@@ -3,13 +3,13 @@ td = require 'testdouble'
 contains = td.matchers.contains
 
 fx = {}
-rp = {}
+axios = {}
 
 id = '101-011-5748031-001'
 
 describe 'candles', ->
   before ->
-    rp = td.replace 'request-promise-native'
+    axios = td.replace 'axios'
     fx = require '../../../index'
     fx.setAccount id
 
@@ -19,7 +19,7 @@ describe 'candles', ->
 
     it 'should pass the parameters for getting the candles of a given instrument id', ->
       fx.candles id: 'AUD_USD', granularity: 'M1'
-      td.verify rp contains
-        uri: 'https://api-fxpractice.oanda.com/v3/instruments/AUD_USD/candles'
+      td.verify axios contains
+        url: 'https://api-fxpractice.oanda.com/v3/instruments/AUD_USD/candles'
         method: 'GET'
-        qs: granularity: 'M1'
+        params: granularity: 'M1'

--- a/test/unit/lib/order.coffee
+++ b/test/unit/lib/order.coffee
@@ -3,13 +3,13 @@ td = require 'testdouble'
 contains = td.matchers.contains
 
 fx = {}
-rp = {}
+axios = {}
 
 id = '101-011-5748031-001'
 
 describe 'orders', ->
   before ->
-    rp = td.replace 'request-promise-native'
+    axios = td.replace 'axios'
     fx = require '../../../index'
     fx.setAccount id
 
@@ -28,24 +28,24 @@ describe 'orders', ->
 
       fx.orders.create {order}
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/orders"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/orders"
         method: 'POST'
-        body: {order}
+        data: {order}
 
   describe 'GET /accounts/:accountId/orders[/:id]', ->
     it 'should pass the parameters get the orders for an account', ->
       fx.orders()
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/orders"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/orders"
         method: 'GET'
 
     it 'should pass the parameters get an order by id for an account', ->
       fx.orders id: 1234
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/orders/1234"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/orders/1234"
         method: 'GET'
 
   describe 'PUT /accounts/:accountId/orders/:id', ->
@@ -63,10 +63,10 @@ describe 'orders', ->
 
       fx.orders.replace {id: 1234, order}
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/orders/1234"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/orders/1234"
         method: 'PUT'
-        body: {order}
+        data: {order}
 
   describe 'PUT /accounts/:accountId/orders/:id/cancel', ->
     it 'should throw an error if missing required params', ->
@@ -75,8 +75,8 @@ describe 'orders', ->
     it 'should pass the parameters to cancel an order', ->
       fx.orders.cancel id: 1234
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/orders/1234/cancel"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/orders/1234/cancel"
         method: 'PUT'
 
   describe 'PUT /accounts/:accountId/orders/:id/clientExtensions', ->
@@ -89,7 +89,7 @@ describe 'orders', ->
 
       fx.orders.clientExtensions {id: 1234, clientExtensions, tradeClientExtensions}
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/orders/1234/clientExtensions"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/orders/1234/clientExtensions"
         method: 'PUT'
-        body: {clientExtensions, tradeClientExtensions}
+        data: {clientExtensions, tradeClientExtensions}

--- a/test/unit/lib/position.coffee
+++ b/test/unit/lib/position.coffee
@@ -3,13 +3,13 @@ td = require 'testdouble'
 contains = td.matchers.contains
 
 fx = {}
-rp = {}
+axios = {}
 
 id = '101-011-5748031-001'
 
 describe 'positions', ->
   before ->
-    rp = td.replace 'request-promise-native'
+    axios = td.replace 'axios'
     fx = require '../../../index'
     fx.setAccount id
 
@@ -17,29 +17,29 @@ describe 'positions', ->
     it 'should pass the parameters to get the positions for an account', ->
       fx.positions()
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/positions"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/positions"
         method: 'GET'
 
     it 'should pass the parameters to get a position by id for an account', ->
       fx.positions id: 'AUD_USD'
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/positions/AUD_USD"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/positions/AUD_USD"
         method: 'GET'
 
     it 'should pass the parameters to get open positions for an account', ->
       fx.positions open: true
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/openPositions"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/openPositions"
         method: 'GET'
 
     it 'should pass the parameters to get the positions for an account per normal', ->
       fx.positions open: false
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/positions"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/positions"
         method: 'GET'
 
   describe 'PUT /accounts/:accountId/positions/:id', ->
@@ -49,6 +49,6 @@ describe 'positions', ->
     it 'should pass the parameters to close position by instrument id', ->
       fx.positions.close id: 'AUD_USD'
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/positions/AUD_USD/close"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/positions/AUD_USD/close"
         method: 'PUT'

--- a/test/unit/lib/pricing.coffee
+++ b/test/unit/lib/pricing.coffee
@@ -3,13 +3,13 @@ td = require 'testdouble'
 contains = td.matchers.contains
 
 fx = {}
-rp = {}
+axios = {}
 
 id = '101-011-5748031-001'
 
 describe 'pricing', ->
   before ->
-    rp = td.replace 'request-promise-native'
+    axios = td.replace 'axios'
     fx = require '../../../index'
     fx.setAccount id
 
@@ -20,7 +20,7 @@ describe 'pricing', ->
     it 'should pass the parameters to get the pricing for a list of instruments', ->
       fx.pricing instruments: 'AUD_USD'
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/pricing"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/pricing"
         method: 'GET'
-        qs: instruments: 'AUD_USD'
+        params: instruments: 'AUD_USD'

--- a/test/unit/lib/subscription.coffee
+++ b/test/unit/lib/subscription.coffee
@@ -3,7 +3,10 @@
 Subscription = require '../../../lib/subscription'
 
 class MockEmitter extends EventEmitter
-  abort: -> @emit 'end', 'its done!'
+  constructor: ->
+    super()
+
+    @req = abort: => @emit 'end', 'its done!'
 
 describe 'Subscription', ->
   describe '#constructor', ->

--- a/test/unit/lib/trade.coffee
+++ b/test/unit/lib/trade.coffee
@@ -3,13 +3,13 @@ td = require 'testdouble'
 contains = td.matchers.contains
 
 fx = {}
-rp = {}
+axios = {}
 
 id = '101-011-5748031-001'
 
 describe 'trades', ->
   before ->
-    rp = td.replace 'request-promise-native'
+    axios = td.replace 'axios'
     fx = require '../../../index'
     fx.setAccount id
 
@@ -17,40 +17,40 @@ describe 'trades', ->
     it 'should pass the parameters to get the trades for an account', ->
       fx.trades count: 10, instrument: 'AUD_USD'
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/trades"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/trades"
         method: 'GET'
-        qs: count: 10, instrument: 'AUD_USD'
+        params: count: 10, instrument: 'AUD_USD'
 
     it 'should set the state filter to open', ->
       fx.trades open: true
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/trades"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/trades"
         method: 'GET'
-        qs: state: 'OPEN'
+        params: state: 'OPEN'
 
     it 'should not change the state filter', ->
       fx.trades open: false, state: 'CLOSED' # pointless but testable
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/trades"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/trades"
         method: 'GET'
-        qs: state: 'CLOSED'
+        params: state: 'CLOSED'
 
     it 'should pass the parameters to get a trade by id for an account', ->
       fx.trades id: 123
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/trades/123"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/trades/123"
         method: 'GET'
 
   describe 'PUT /accounts/:accountId/trades/:id/close', ->
     it 'should pass the parameters to close a trade by id', ->
       fx.trades.close id: 123
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/trades/123/close"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/trades/123/close"
         method: 'PUT'
 
   describe 'PUT /accounts/:accountId/trades/:id/clientExtensions', ->
@@ -58,10 +58,10 @@ describe 'trades', ->
       clientExtensions = id: 'ABC123', tag: 'MEGA1', comment: 'awesome dood'
       fx.trades.clientExtensions {id: 123, clientExtensions}
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/trades/123/clientExtensions"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/trades/123/clientExtensions"
         method: 'PUT'
-        body: {clientExtensions}
+        data: {clientExtensions}
 
   describe 'PUT /accounts/:accountId/trades/:id/orders', ->
     # TODO: Not putting much into this test, looks like an 'interesting' route...
@@ -70,7 +70,7 @@ describe 'trades', ->
 
       fx.trades.orders {id: 123, takeProfit}
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/trades/123/orders"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/trades/123/orders"
         method: 'PUT'
-        body: {takeProfit}
+        data: {takeProfit}

--- a/test/unit/lib/transaction.coffee
+++ b/test/unit/lib/transaction.coffee
@@ -3,13 +3,13 @@ td = require 'testdouble'
 contains = td.matchers.contains
 
 fx = {}
-rp = {}
+axios = {}
 
 id = '101-011-5748031-001'
 
 describe 'transactions', ->
   before ->
-    rp = td.replace 'request-promise-native'
+    axios = td.replace 'axios'
     fx = require '../../../index'
     fx.setAccount id
 
@@ -17,14 +17,14 @@ describe 'transactions', ->
     it 'should pass the parameters to get the transactions for an account', ->
       fx.transactions pageSize: 10, type: 'CLIENT_CONFIGURE'
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/transactions"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/transactions"
         method: 'GET'
-        qs: pageSize: 10, type: 'CLIENT_CONFIGURE'
+        params: pageSize: 10, type: 'CLIENT_CONFIGURE'
 
     it 'should pass the parameters to get a transaction by id for an account', ->
       fx.transactions id: 123
 
-      td.verify rp contains
-        uri: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/transactions/123"
+      td.verify axios contains
+        url: "https://api-fxpractice.oanda.com/v3/accounts/#{id}/transactions/123"
         method: 'GET'


### PR DESCRIPTION
This PR replaces `request` / `request-promise` with `axios`

Changes:
- Greatly reduces the bundle size to 43kb for the browser, so resolves #6 
- Changes the way subscriptions work as they now must resolve Promises, to yield the stream

Needed:
- Requires documentation change to reflect impact of stream changes
- Need some more testing to ensure ok and functioning as expected.
- Likely 2.0 release as is breaking change to stream functionality? Dunno as unsure anyone uses this but me right now so might be ok to break.