### PR TITLE
Fixes a subscription issue with empty buffers

### DIFF
--- a/lib/subscription.coffee
+++ b/lib/subscription.coffee
@@ -12,7 +12,12 @@ class Subscription extends EventEmitter
 
     @stream.on 'data', (data) =>
       @connected = true
-      if @options.json then data = JSON.parse data.toString()
+      if @options.json
+        str = data.toString()
+
+        if !str then return
+
+        data = JSON.parse str
 
       @emit 'data', data
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-fxtrade",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-fxtrade",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A node js wrapper for the Oanda Rest v20 api to make things really simple",
   "main": "dist/node.js",
   "browser": "dist/browser.js",

--- a/test/integration/index.coffee
+++ b/test/integration/index.coffee
@@ -45,7 +45,8 @@ describe '--- Integration Tests ---', ->
     describe 'GET /accounts/:id/changes', ->
       it 'should return the account changes', ->
         fx.setAccount id
-        {changes: {transactions}} = await fx.changes sinceTransactionID: 364
+        {lastTransactionID} = await fx.transactions()
+        {changes: {transactions}} = await fx.changes sinceTransactionID: +lastTransactionID - 1
 
         expect(_.isEmpty transactions).to.not.be.ok
 

--- a/test/unit/lib/subscription.coffee
+++ b/test/unit/lib/subscription.coffee
@@ -44,6 +44,15 @@ describe 'Subscription', ->
 
       emitter.emit 'data', '{"stuff":"worked"}'
 
+    it 'should not explode if the data is empty and no event should be emitted', (done) ->
+      emitter = new MockEmitter
+      sub = new Subscription emitter, json: true
+      sub.on 'data', (data) -> expect.fail()
+
+      emitter.emit 'data', Buffer.from ''
+      sub.on 'end', -> done()
+      sub.disconnect()
+
   describe '#on end / disconnect', ->
     it 'should disconnect the subscription', (done) ->
       emitter = new MockEmitter


### PR DESCRIPTION
Adds a check for the string data coming from buffers to ensure its valid before parsing as json. Related to #17 

Not sure when it happens that the buffer data is empty but if there is no 'type' on a subscription post 'toString' then its not going to be valid for this api. In these cases its _probably_ an empty string that is getting passed so....

These oddball scenarios will not be output as a 'data' event either so if that causes an issue downstream for users of the api its really more of a problem related to their connections or oanda api... Maybe this could be an error but not sure at the moment just lets not explode.