### PR TITLE
Fixes possible sub issue with multiple messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-fxtrade",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Fixes #20  by splitting the buffered string data by new line and emitting each message in order.