### PR TITLE
Add error handling for JSON.parse errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-fxtrade",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-fxtrade",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "A node js wrapper for the Oanda Rest v20 api to make things really simple",
   "main": "dist/node.js",
   "browser": "dist/browser.js",

--- a/test/unit/lib/subscription.coffee
+++ b/test/unit/lib/subscription.coffee
@@ -74,6 +74,21 @@ describe 'Subscription', ->
       '
       sub.disconnect()
 
+    it 'should emit an error when json data is not parsed successfully', (done) ->
+      sub = new Subscription emitter, json: true
+      dataHandler = td.func()
+      errorHandler = td.func()
+      sub.on 'data', dataHandler
+      sub.on 'error', errorHandler
+      sub.on 'end', ->
+        expect(td.explain(dataHandler).callCount).to.equal 0
+        expect(td.explain(errorHandler).callCount).to.equal 1
+        expect(td.explain(errorHandler).calls[0].args[0].message).to.match /Subscription error parsing Oanda response/
+        done()
+
+      emitter.emit 'data', '}{}\n}invalid json'
+      sub.disconnect()
+
 
   describe '#on end / disconnect', ->
     it 'should disconnect the subscription', (done) ->


### PR DESCRIPTION
Per comments in #17 this PR introduces some error handling so that the api won't crash for unknown reasons in the event that Oanda send some junk through the stream.

There is no 'type' check because if they just send a string of text it may be valid and have some information that isn't documented, i dont think the wrapper should make assumptions about the structure unless necessary.